### PR TITLE
Added JSON response in console to use it externally

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const defaultOptions = {
   prefix: '',
   spacer: 7,
+  toJson: false
 };
 
 const COLORS = {
@@ -78,7 +79,7 @@ function getStacks(app) {
 module.exports = function expressListRoutes(app, opts) {
   const stacks = getStacks(app);
   const options = { ...defaultOptions, ...opts };
-
+  let jsonResp = [];
   if (stacks) {
     for (const stack of stacks) {
       if (stack.route) {
@@ -91,11 +92,21 @@ module.exports = function expressListRoutes(app, opts) {
             const stackPath = path.resolve(
               [options.prefix, stack.routerPath, stack.route.path, route.path].filter((s) => !!s).join(''),
             );
-            console.info(stackMethod, stackSpace, stackPath);
+            if(options.toJson) {
+              jsonResp.push({
+                "method": method,
+                "path": stackPath
+              })
+            } else {
+              console.info(stackMethod, stackSpace, stackPath);
+            }
             routeLogged[method] = true;
           }
         }
       }
     }
+  }
+  if(options.toJson) {
+    console.info(JSON.stringify(jsonResp, null, options.spacer));
   }
 };

--- a/index.tests.js
+++ b/index.tests.js
@@ -175,5 +175,6 @@ describe('express 5', () => {
       ['\u001b[32mGET\u001b[39m', '', '/api/v1/user'],
       ['\u001b[33mPOST\u001b[39m', '', '/api/v1/user'],
     ]);
+    expressListRoutes(app, { prefix: '/api/v1', spacer: 2, toJson: true });
   });
 });

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,22 @@ expressListRoutes(router);
 // GET    /admin/user
 // PUT    /admin/user
 ```
+**List all Routes with prefix and log out in JSON format**
+```js
+expressListRoutes(app, { prefix: '/api/v1', toJson: true, spacer: 2 });
+// Logs out the following:
+  [
+    {
+      "method": "GET",
+      "path": "/api/v1/user"
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/user"
+    }
+  ]
+
+```
 
 ## Installation
 
@@ -51,7 +67,8 @@ You can pass a second argument to set some options
 ```js
   {
     prefix: '', // A prefix for router Path
-    spacer: 7   // Spacer between router Method and Path
+    spacer: 7,   // Spacer between router Method and Path
+    toJson: true  // Show route in JSON format to use it externally
   }
 ```
 


### PR DESCRIPTION
Displaying Routes info in JSON/Object format. We can easily copy and use it into our application. 

Reason:
While creating middle-ware, we have to whitelist and blacklist some URLs. When route count increases, normal console log will not be useful. We may need programmatic format to use it directly into our application. So, I have added the JSON/Object response as a option with route list view.