### PR TITLE
fix: type for support Express4 router and so on

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,27 +2,30 @@ interface Options {
   spacer?: number;
   prefix?: string;
   logger?: (method: string, space: string, path: string) => void;
+  color?: boolean;
 }
 
 interface Route {
-  method?: string;
+  method?: string | object;
   path?: string;
 }
 
-interface Stack {
-  route?: {
-    stack: Route[];
-    path?: string;
-  };
-  routerPath?: string;
+interface Layer {
+  name: string;
+  route?: Route;
 }
 
 interface ExpressApp {
-  _router: {
-    stack: Stack[];
-  };
+  // Express 3
+  routes?: Record<string, Route[][]>;
+  // Express 4
+  _router?: { stack: Layer[] };
+  // Express 4, 5 Router
+  stack?: Layer[];
+  // Express 5
+  router?: { stack: Layer[] } | string;
 }
 
 declare function expressListRoutes(app: ExpressApp, options?: Options): Array<{ method: string; path: string }>;
 
-export { expressListRoutes as default };
+export = expressListRoutes;


### PR DESCRIPTION
This ought to fix https://github.com/labithiotis/express-list-routes/issues/20.

Type definitions have been modified to accommodate all Express 3, 4, and 5.

Also, router is now supported.