### PR TITLE
Support for Boolean Type in Logger Option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 interface Options {
   spacer?: number;
   prefix?: string;
-  logger?: (method: string, space: string, path: string) => void;
+  logger?: ((method: string, space: string, path: string) => void) | boolean;
   color?: boolean;
 }
 

--- a/index.js
+++ b/index.js
@@ -82,6 +82,8 @@ function getStacks(app) {
   return [];
 }
 
+
+
 module.exports = function expressListRoutes(app, opts) {
   const stacks = getStacks(app);
   const options = { ...defaultOptions, ...opts };
@@ -99,7 +101,11 @@ module.exports = function expressListRoutes(app, opts) {
             const stackPath = path
               .normalize([options.prefix, stack.routerPath, stack.route.path, route.path].filter((s) => !!s).join(''))
               .trim();
-            options.logger(stackMethod, stackSpace, stackPath);
+              if (options.logger === true) {
+                defaultOptions.logger(stackMethod, stackSpace, stackPath);
+              } else if (typeof options.logger === 'function') {
+                options.logger(stackMethod, stackSpace, stackPath);
+              }
             paths.push({ method, path: stackPath });
             routeLogged[method] = true;
           }

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ You can pass a second argument to set some options
   {
     prefix: '', // A prefix for router Path
     spacer: 7   // Spacer between router Method and Path
-    logger: console.info // A custom logger function
+    logger: console.info // A custom logger function or a boolean (true for default logger, false for no logging)
     color: true // If the console log should color the method name
   }
 ```


### PR DESCRIPTION
## Description
This pull request adds support for using a boolean value in the logger option within the Options interface. This enhancement allows users to enable or disable logging functionality with a simple boolean flag (true or false) in addition to the existing capability of providing a custom logging function.

## Detailed Changes
  1. ### Modified `Options` Interface: 
  - The `logger` property in the `Options` interface now accepts either a function of type `(method: string, space: string, path: string) => void` or a `boolean`.
  2. ### Updated `expressListRoutes` Function:

-   Implemented logic to handle `logger` being `true`, `false`, or a `function`.
-   When `logger` is `true`, the default logger `console.info` is used.
-   When `logger` is `false`, no logging occurs.
-   When `logger` is a function, the provided function is used for logging.

## Benefits

- Flexibility: Users can now easily enable or disable logging with a boolean flag.
- Backward Compatibility: Existing functionality with a custom logging function remains unchanged.
- Simplicity: Simplifies the configuration for users who only need basic logging enabled or disabled.

### Example Usage

```js
const expressListRoutes = require('express-list-routes');

//  logger enabled, using default logger (true)
expressListRoutes(app, {
  logger: true,
});

// logger disabled (false)
expressListRoutes(app, {
  logger: false,
});

// custom logger
expressListRoutes(app, {
  logger: console.warn
});

// default
expressListRoutes(app);

```
**XOXO ❤️**