### PR TITLE
feat: add forceUnixPathStyle option and improve regex cleanup refs #27

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ interface Options {
   prefix?: string;
   logger?: ((method: string, space: string, path: string) => void) | boolean;
   color?: boolean;
+  forceUnixPathStyle?: boolean;
 }
 
 interface Route {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const defaultOptions = {
   spacer: 7,
   logger: console.info,
   color: true,
+  forceUnixPathStyle: false,
 };
 
 const COLORS = {
@@ -43,8 +44,10 @@ function getPathFromRegex(regexp) {
     .toString()
     .replace('/^', '')
     .replace('?(?=\\/|$)/i', '')
+    .replace('\\?(?=\\\\|$)', '') // Remove \?(?=\\|$) pattern as string
     .replace(/\\\//g, '/')
-    .replace('(?:/(?=$))', '');
+    .replace('(?:/(?=$))', '')
+    .replace(/\/i$/, ''); // Remove trailing /i flag
 }
 
 function combineExpress4Stacks(acc, stack) {
@@ -109,9 +112,12 @@ module.exports = function expressListRoutes(app, opts) {
           if (!routeLogged[method] && method) {
             const stackMethod = options.color ? colorMethod(method) : method;
             const stackSpace = spacer(options.spacer - method.length);
-            const stackPath = path
+            let stackPath = path
               .normalize([options.prefix, stack.routerPath, stack.route.path, route.path].filter((s) => !!s).join(''))
               .trim();
+            if (options.forceUnixPathStyle) {
+              stackPath = stackPath.replace(/\\/g, '/');
+            }
             if (options.logger === true) {
               defaultOptions.logger(stackMethod, stackSpace, stackPath);
             } else if (typeof options.logger === 'function') {

--- a/index.tests.js
+++ b/index.tests.js
@@ -265,7 +265,7 @@ describe('unknown app', () => {
   });
 });
 
-describe('new features', () => {
+describe('path styles', () => {
   it('converts backslashes to forward slashes when forceUnixPathStyle is true', () => {
     const logger = jest.fn();
     const app = express4();

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ You can pass a second argument to set some options
     spacer: 7   // Spacer between router Method and Path
     logger: console.info // A custom logger function or a boolean (true for default logger, false for no logging)
     color: true // If the console log should color the method name
+    forceUnixPathStyle: false // Convert Windows backslashes to forward slashes for consistent path display across platforms
   }
 ```
 
@@ -76,6 +77,16 @@ You can pass a second argument to set some options
 <details open>
 <summary>Errors with importing this library</summary>
 You may need to enable esModuleInterop in your tsconfig.json to support default exports.
+</details>
+
+<details>
+<summary>Windows path display shows backslashes</summary>
+On Windows systems, paths may display with backslashes (e.g., `\admin\user`) instead of forward slashes. This is due to Node.js path.normalize() behavior on Windows. To ensure consistent Unix-style paths across all platforms, set the `forceUnixPathStyle` option to `true`:
+
+```js
+expressListRoutes(app, { forceUnixPathStyle: true });
+// This will display: /admin/user (even on Windows)
+```
 </details>
 
 For Express5 currently nested routes will all be printted out as `~` as theres no way to get parent router path from app object that I'm aware of.


### PR DESCRIPTION
This ought to resolve https://github.com/labithiotis/express-list-routes/issues/27.

## Summary

  Fixes Windows path display issues by adding `forceUnixPathStyle` option and improving regex cleanup.

  ## Problem

  Windows users see paths with backslashes and regex artifacts:
  POST    \topics(?=$)\import
  GET     \topics(?=$)topicId

  ## Solution

  - **New option**: `forceUnixPathStyle: true` converts backslashes to forward slashes
  - **Regex cleanup**: Removes `\?(?=\\|$)` patterns and trailing `/i` flags

  ## Usage

  ```javascript
  expressListRoutes(app, { forceUnixPathStyle: true });
  // Output: /topics/:topicId (not \topics\?(?=\|$)\:topicId)
```

  Changes

  - Added forceUnixPathStyle option (default: false)
  - Enhanced getPathFromRegex() to remove regex artifacts
  - Updated TypeScript definitions and documentation
  - Added 3 tests for new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Added an option to enforce Unix-style path formatting for route paths, ensuring consistent display across platforms.

- **Bug Fixes**
  - Improved normalization of route paths by removing specific regex patterns and trailing flags.

- **Documentation**
  - Updated usage instructions and added an FAQ to explain the new path formatting option and cross-platform behavior.

- **Tests**
  - Added tests to verify Unix-style path enforcement and improved route path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->