### PR TITLE
chore: add path fallback opt

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ interface Options {
   logger?: ((method: string, space: string, path: string) => void) | boolean;
   color?: boolean;
   forceUnixPathStyle?: boolean;
+  pathFallback?: string;
 }
 
 interface Route {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function combineExpress5Stacks(acc, stack, opts) {
     // Tried looking through whole express app object and
     // couldn't find any reference for nested routes.
     // For now we just intedcated nested routes with ~
-    const routerPath = stack.path ?? opts.pathFallback ?? '/~';
+    const routerPath = stack.path ?? opts?.pathFallback ?? '/~';
     return [...acc, ...stack.handle.stack.map((nestedStack) => ({ routerPath, ...nestedStack }))];
   }
   return [...acc, stack];

--- a/index.tests.js
+++ b/index.tests.js
@@ -205,13 +205,13 @@ describe('express 5', () => {
 
     app.use('/admin', router);
 
-    expressListRoutes(app, { logger, prefix: '/api/v1' });
+    expressListRoutes(app, { logger, prefix: '/api/v1', pathFallback: '/admin' });
 
     expect(logger.mock.calls).toEqual([
       ['\u001b[32mGET\u001b[39m', '    ', '/api/v1/test'],
-      ['\u001b[33mPOST\u001b[39m', '   ', '/api/v1/~/user'], // FIXME express5 we can't get the router path for nested
-      ['\u001b[32mGET\u001b[39m', '    ', '/api/v1/~/user'], // FIXME express5 we can't get the router path for nested
-      ['\u001b[34mPUT\u001b[39m', '    ', '/api/v1/~/user'], // FIXME express5 we can't get the router path for nested
+      ['\u001b[33mPOST\u001b[39m', '   ', '/api/v1/admin/user'], // FIXME express5 we can't get the router path for nested
+      ['\u001b[32mGET\u001b[39m', '    ', '/api/v1/admin/user'], // FIXME express5 we can't get the router path for nested
+      ['\u001b[34mPUT\u001b[39m', '    ', '/api/v1/admin/user'], // FIXME express5 we can't get the router path for nested
     ]);
   });
 
@@ -269,18 +269,18 @@ describe('path styles', () => {
   it('converts backslashes to forward slashes when forceUnixPathStyle is true', () => {
     const logger = jest.fn();
     const app = express4();
-    
+
     // Mock Windows environment by manipulating the path separator
     const originalSep = require('path').sep;
     require('path').sep = '\\';
-    
+
     app.get('/test/path', handler);
-    
+
     const paths = expressListRoutes(app, { logger, forceUnixPathStyle: true });
-    
+
     // Restore original separator
     require('path').sep = originalSep;
-    
+
     // Even on Windows, with forceUnixPathStyle: true, paths should use forward slashes
     expect(paths[0].path).toContain('/');
     expect(paths[0].path).not.toContain('\\');
@@ -288,25 +288,27 @@ describe('path styles', () => {
 
   it('removes ?(?=\\|$) pattern from paths', () => {
     const app = express4();
-    
+
     // Create a mock stack entry that simulates a regex with the problematic pattern
     const mockStack = {
       regexp: /^\/test\?(?=\\|$)/i,
       handle: {
-        stack: [{
-          route: {
-            path: '/endpoint',
-            stack: [{ method: 'get' }]
-          }
-        }]
-      }
+        stack: [
+          {
+            route: {
+              path: '/endpoint',
+              stack: [{ method: 'get' }],
+            },
+          },
+        ],
+      },
     };
-    
+
     // Override the app's router stack with our mock
     app._router = { stack: [mockStack] };
-    
+
     const paths = expressListRoutes(app, { logger: false });
-    
+
     // The pattern should be removed from the final path
     expect(paths).toHaveLength(1);
     expect(paths[0].path).not.toContain('?(?=\\|$)');
@@ -315,33 +317,35 @@ describe('path styles', () => {
 
   it('handles Windows paths with regex patterns as reported in issue', () => {
     const app = express4();
-    
+
     // Simulate the exact pattern from the issue: \topics\?(?=\|$)\:topicId
     const mockStack = {
       regexp: /^\\topics\\?(?=\\|$)/i,
       handle: {
-        stack: [{
-          route: {
-            path: '/:topicId',
-            stack: [{ method: 'get' }]
-          }
-        }]
-      }
+        stack: [
+          {
+            route: {
+              path: '/:topicId',
+              stack: [{ method: 'get' }],
+            },
+          },
+        ],
+      },
     };
-    
+
     app._router = { stack: [mockStack] };
-    
+
     // Test without forceUnixPathStyle
     let paths = expressListRoutes(app, { logger: false });
-    
+
     // Should not contain the regex pattern
     expect(paths[0].path).not.toContain('?(?=\\|$)');
     // On Linux/Unix, backslashes should remain as is without the option
     expect(paths[0].path).toBe('\\\\topics/:topicId');
-    
+
     // Test with forceUnixPathStyle
     paths = expressListRoutes(app, { logger: false, forceUnixPathStyle: true });
-    
+
     // Should convert backslashes to forward slashes
     expect(paths[0].path).toBe('//topics/:topicId');
   });

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ You can pass a second argument to set some options
     logger: console.info // A custom logger function or a boolean (true for default logger, false for no logging)
     color: true // If the console log should color the method name
     forceUnixPathStyle: false // Convert Windows backslashes to forward slashes for consistent path display across platforms
+    pathFallback: '/~' // Fallback path value for nested routes
   }
 ```
 


### PR DESCRIPTION
Resolves https://github.com/labithiotis/express-list-routes/issues/29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional pathFallback configuration to customize how nested Express 5 router paths are resolved.

* **Documentation**
  * README updated to document the new pathFallback option and its default behavior.

* **Tests**
  * Tests updated to reflect the new resolved paths when using the pathFallback option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->